### PR TITLE
Add set -e to bash scripts to make it easier to spot/find errors

### DIFF
--- a/setup-cuda.sh
+++ b/setup-cuda.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # get local dependencies
+set -e # Stop running when an error happens
+
 git submodule init
 git submodule update --remote
 # setup venv

--- a/setup-docker.sh
+++ b/setup-docker.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e # Stop on any command erroring
+
 git submodule init
 git submodule update --remote
 docker build -t ai-voice-cloning .

--- a/setup-rocm-bnb.sh
+++ b/setup-rocm-bnb.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e # stop on error
+
 source ./venv/bin/activate
 # swap to ROCm version of BitsAndBytes
 pip3 uninstall -y bitsandbytes

--- a/setup-rocm.sh
+++ b/setup-rocm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # Stop on error
 # get local dependencies
 git submodule init
 git submodule update --remote


### PR DESCRIPTION
Just a small quality of life update.  Adding this means that if there's any errors when running the commands in the scripts, it'll exit immediately, making it easier to see the problem.  This can easily happen during building/installing tortoise because it requires a modern and working rust compiler to fully build from source here.  This should make it easier to spot the problem since the error won't be pushed way up by the other pip commands.