### PR TITLE
Update start-docker.sh

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -4,6 +4,7 @@ docker run \
     -ti \
     --rm \
     --gpus all \
+    --ipc=host
     --name ai-voice-cloning \
     -v "${PWD}/models:/home/user/ai-voice-cloning/models" \
     -v "${PWD}/training:/home/user/ai-voice-cloning/training" \


### PR DESCRIPTION
use --ipc=host can avoid shm error (ERROR: Unexpected bus error encountered in worker. This might be caused by insufficient shared memory (shm).)